### PR TITLE
Add Docker to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,10 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Build the project
-      run: cmake -S . -B build
-    - name: Compile the executable
-      run: cd build && cmake --build .
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: docker build -t coolstory-gram-server .
+      - name: Run the application with Docker
+        run: docker run coolstory-gram-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM coolstory/alpine-boost:1.82
+
+# Copy application sources
+COPY . /app
+WORKDIR /app
+
+# Build the project
+RUN cmake -S . -B build && \
+    cd build && \
+    make
+
+# Run the application
+RUN ./build/coolstory_gram_server


### PR DESCRIPTION
- Add Dockerfile to build and run application;
- Update GitHub CI to use Docker Image with Boost library.