### PR TITLE
CMake with vendor libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ set(CMAKE_CXX_STANDARD 17)
 
 find_package(Boost 1.74 REQUIRED)
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
+FetchContent_Declare(
+	json
+	GIT_REPOSITORY https://github.com/nlohmann/json.git
+	GIT_TAG bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d # release/3.11.2
+)
 FetchContent_MakeAvailable(json)
 
 include_directories(include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 3.22)
 project(coolstory_gram_server)
+include(FetchContent)
 
 set(CMAKE_CXX_STANDARD 17)
 
 find_package(Boost 1.74 REQUIRED)
 
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
+FetchContent_MakeAvailable(json)
+
 include_directories(include)
 
 add_executable(coolstory_gram_server src/main.cpp)
+target_link_libraries(coolstory_gram_server PRIVATE nlohmann_json::nlohmann_json)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(coolstory_gram_server)
 
 set(CMAKE_CXX_STANDARD 17)
 
+find_package(Boost 1.74 REQUIRED)
+
 include_directories(include)
 
 add_executable(coolstory_gram_server src/main.cpp)


### PR DESCRIPTION
PR contains few `CMakeLists.txt` changes:
- Now cmake requires the Boost 1.74 or newer;
- Also cmake automatically downloads and links [nlohmann_json](https://github.com/nlohmann/json) with our project.